### PR TITLE
chore: gitignore .pnpm-store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+.pnpm-store
 node_modules
 dist
 dist-ssr


### PR DESCRIPTION
When opening the project in the devcontainer/codespaces, the `.pnpm-store` will be in the workspace directory, I think it's needed to gitignore it.